### PR TITLE
Fix: Invalid Study Board Amount Being Set on Application Table

### DIFF
--- a/src/web/src/components/application/csfa-needs-assessment/AccommodationForm.vue
+++ b/src/web/src/components/application/csfa-needs-assessment/AccommodationForm.vue
@@ -37,7 +37,7 @@
               @change="
                 doSaveApp(
                   'prestudy_board_amount',
-                  application.prestudy_board_amount
+                  vueCurrencyInputParse(application.prestudy_board_amount),
                 )
               "
             ></v-text-field>

--- a/src/web/src/components/application/csfa-needs-assessment/AccommodationForm.vue
+++ b/src/web/src/components/application/csfa-needs-assessment/AccommodationForm.vue
@@ -18,7 +18,7 @@
                   doSaveApp(
                     'prestudy_accom_code',
                     application.prestudy_accom_code
-                  );                  
+                  );
                 }
               "
               item-text="description"
@@ -43,7 +43,7 @@
             ></v-text-field>
           </div>
           <div class="col-md-4 pt-0">
-            <v-switch          
+            <v-switch
               outlined
               dense
               hide-details
@@ -163,7 +163,7 @@
               v-model="application.study_board_amount"
               v-currency="{ currency: 'USD', locale: 'en' }"
               @change="
-                doSaveApp('study_board_amount', application.study_board_amount)
+                doSaveApp('study_board_amount', vueCurrencyInputParse(application.study_board_amount))
               "
             ></v-text-field>
           </div>
@@ -252,9 +252,12 @@
 </template>
 
 <script>
+import { parse as vueCurrencyInputParse } from "vue-currency-input"
+
 import store from "@/store";
 import { mapGetters } from "vuex";
 import validator from "@/validator";
+
 export default {
   data: () => ({
     housingOptions: [
@@ -284,7 +287,7 @@ export default {
       living_with_spouse: false,
       bus_available: false,
       distance_from_school: 0,
-    },    
+    },
     validate: {},
   }),
   computed: {
@@ -305,6 +308,7 @@ export default {
     logSelectedOption() {
       console.log(`Selected option: ${this.prestudy.housing}`);
     },
+    vueCurrencyInputParse,
   },
 };
 </script>


### PR DESCRIPTION
Relates to https://github.com/icefoganalytics/sfa-client/issues/53

# Context

Invalid study_board_amount being set on application table.
```
FAILED RequestError: update [sfa].[application] set [study_board_amount] = @p0 where [id] = @p1;select @@rowcount - Error converting data type nvarchar to numeric.
```
Relates to:
- `src/web/src/components/application/csfa-needs-assessment/AccommodationForm.vue`

The bug is an incorrect use of https://vue-currency-input-v1.netlify.app/guide/#getting-the-number-value

## Concerns

1. Bug may exist in `prestudy_board_amount` field as well.

# Implementation

Expose `vue-currency-input` library `parse` method, and parse the string values before saving it.
It might make sense, in the future, to build a custom v-currency-text-field that automates this effect.

Also trim trailing whitespace on save. It might be a good idea to set up linting, or to tweak the VS Code config such that the `"files.trimTrailingWhitespace"` property to `true`. See https://bobbyhadz.com/blog/remove-trailing-whitespace-vscode

# Testing/QA Instructions

1. TODO ...