### PR TITLE
Fix: Invalid Book Supplies Cost Being Set on Applications Table

### DIFF
--- a/src/web/src/components/application/csfa-needs-assessment/costs/StudyExpensesForm.vue
+++ b/src/web/src/components/application/csfa-needs-assessment/costs/StudyExpensesForm.vue
@@ -26,8 +26,13 @@
               hide-details
               label="Books & supplies"
               v-model="application.books_supplies_cost"
-              @change="doSaveApp('books_supplies_cost', application.books_supplies_cost)"
               v-currency="{ currency: 'USD', locale: 'en' }"
+              @change="
+                doSaveApp(
+                  'books_supplies_cost',
+                  vueCurrencyInputParse(application.books_supplies_cost)
+                )
+              "
             ></v-text-field>
           </div>
           <div class="col-md-6">
@@ -157,6 +162,7 @@
 </template>
 
 <script>
+import { parse as vueCurrencyInputParse } from "vue-currency-input"
 import { mapGetters } from "vuex";
 import store from "@/store";
 import { APPLICATION_URL } from "@/urls";


### PR DESCRIPTION
Relates to https://github.com/icefoganalytics/sfa-client/issues/53

# Context
Invalid book_supplies_cost being set on applications table.
```
FAILED RequestError: update [sfa].[application] set [books_supplies_cost] = @p0 where [id] = @p1;select @@rowcount - Conversion failed when converting the nvarchar value '876.75' to data type int.
```
Relates to:
- `src/web/src/components/application/csfa-needs-assessment/costs/StudyExpensesForm.vue`

## Concerns

1. This not a complete fix as the input supports cents, but the database column is an integer. These are some options to fix the problem.
    a. (highest quality) Save all money values in the database as a values in cents. e.g. book_supplies_cost_in_cents and perform conversions in the UI. 
    b. (sane, but still easy to do) Migrate the `books_supplies_cost` column and make it a "numeric" to match the `study_board_amount` column.
    c. (messy, but quick) Only support whole dollars in the UI, and add a tooltip suggesting data should be rounded up manually.

# Implementation

Expose `vue-currency-input` library `parse` method, and parse the string values before saving it.
It might make sense, in the future, to build a custom v-currency-text-field that automates this effect.

# Testing/QA Instructions

1. TODO ...