### PR TITLE
Fix: Invalid Foreign Key Being Set on Student Table

### DIFF
--- a/src/api/models/application.ts
+++ b/src/api/models/application.ts
@@ -7,6 +7,7 @@ import Institution from "@/models/institution";
 import ParentDependent from "@/models/parent-dependent";
 import PersonAddress from "@/models/person-address";
 import Program from "@/models/program";
+import HighSchool from "@/models/high-school";
 import Student from "@/models/student";
 
 // Application with standard JS naming conventions
@@ -623,7 +624,12 @@ export function StudentFromDraft(draft: any): any {
   let studentUpdate = {} as any;
 
   if (educations) {
-    studentUpdate.high_school_id = educations[0].school;
+    if (educations[0].school === -1) {
+      studentUpdate.high_school_id = HighSchool.SpecialTypes.NOT_LISTED
+    } else {
+      studentUpdate.high_school_id = educations[0].school;
+    }
+
     studentUpdate.high_school_left_year = educations[0].left_high_school.split("/")[0];
     studentUpdate.high_school_left_month = educations[0].left_high_school.split("/")[1];
     studentUpdate.is_crown_ward = draft.statistical.crown_ward;

--- a/src/api/models/high-school.ts
+++ b/src/api/models/high-school.ts
@@ -1,0 +1,20 @@
+enum SpecialTypesOfHighSchools {
+  NOT_LISTED = 0,
+}
+
+export interface HighSchoolRecord {
+  id: number
+  name: string
+  cityId: number
+  provinceId: number
+  countryId: number
+  isActive: boolean
+}
+
+interface HighSchool extends HighSchoolRecord {}
+
+class HighSchool {
+  static readonly SpecialTypes = SpecialTypesOfHighSchools
+}
+
+export default HighSchool


### PR DESCRIPTION
Relates to https://github.com/icefoganalytics/sfa-client/issues/53

Invalid foreign key being set on student table.
```
Error: update [sfa].[student] set [high_school_id] = @p0, [high_school_left_year] = @p1, [high_school_left_month] = @p2 where [id] = @p3;select @@rowcount - The UPDATE statement conflicted with the FOREIGN KEY constraint "FK__student__high_sc__13AF0337". The conflict occurred in database "EDU_SFA", table "sfa.high_school", column 'id'.
```

Relates to:
- https://github.com/icefoganalytics/sfa-client/blob/7d81d2ce8ff778b09caee1b6600dd12a6d152af6/src/api/models/application.ts#L634
- https://github.com/icefoganalytics/student-financial-aid/blob/498c6226b594a555895274dc998ec97d2ba49268/src/web/src/modules/draft/views/education-history.vue#L21
- https://github.com/icefoganalytics/student-financial-aid/blob/498c6226b594a555895274dc998ec97d2ba49268/src/web/src/store/ReferenceStore.ts#L119

# Implemenation

Fix student from draft conversion of high school id.
The front-end `student-finanical-aid` is setting this line of code
```
this.yukonHighSchools.unshift({ id: -1, name: "I did not attend a Yukon high school" });
```
But the `-1` id does not map to anything in the back end. The intent appears to be to map to the special "Not Listed" record in the `high_school` table, so I'm mapping at the final stage to avoid dealing with special constants in the front-end.

# Testing Instructions

1. In the `sfa-client` repo boot the back-end via `API_PORT=3100 dev up`
2. In the `student-financial-aid` repo boot the back-end via `cd src/api && npm run start`
3. In the `student-financial-aid` repo boot the front-end via `cd src/web && npm run start`
4. Go to `http://localhost:8080` and log in.
5. After logging in, and creating a draft application, go to the "education history" section and select "I did not attend a Yukon high school"
6. Submit the draft, and see that the `sfa-client` back-end the no longer crashes.